### PR TITLE
add biomodalQC_miseq name

### DIFF
--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -1,6 +1,7 @@
 {
     "names": [
-        "biomodalQC"
+        "biomodalQC",
+	"biomodalQC_miseq"
     ],
     "wdl": "biomodalQC.wdl"
 }


### PR DESCRIPTION
biomodalQC running speed and very different when running on miseq (very fast) and full-depth data (very slow). I am planing to use two different vidarr names and assign different maxInFlight. Doing so prioritise miseq runs so QC check will be fastq and for some projects TGL lab can have initial conclusion of the QC status.